### PR TITLE
tofu: drop Auth0 provider remnants and stale locals

### DIFF
--- a/tofu/keyvault.tf
+++ b/tofu/keyvault.tf
@@ -3,11 +3,6 @@ data "azurerm_key_vault" "main" {
   resource_group_name = local.infra.resource_group_name
 }
 
-data "azurerm_key_vault_secret" "auth0_client_secret" {
-  name         = "auth0-client-secret"
-  key_vault_id = data.azurerm_key_vault.main.id
-}
-
 resource "random_password" "jwt_signing_secret" {
   length  = 64
   special = false

--- a/tofu/provider.tf
+++ b/tofu/provider.tf
@@ -10,9 +10,3 @@ provider "azurerm" {
 provider "azapi" {
   use_oidc = true
 }
-
-provider "auth0" {
-  domain        = "dev-gtdi5x5p0nmticqd.us.auth0.com"
-  client_id     = "7qsN7zrBAh7TwhjEUcgtU46yOSs9TXbg"
-  client_secret = data.azurerm_key_vault_secret.auth0_client_secret.value
-}

--- a/tofu/remote-state.tf
+++ b/tofu/remote-state.tf
@@ -1,11 +1,11 @@
 locals {
   infra = {
-    resource_group_name            = "infra"
-    dns_zone_name                  = "romaine.life"
-    cosmos_db_account_name         = "infra-cosmos"
-    cosmos_db_account_id           = "/subscriptions/aee0cbd2-8074-4001-b610-0f8edb4eaa3c/resourceGroups/infra/providers/Microsoft.DocumentDB/databaseAccounts/infra-cosmos"
-    azure_app_config_endpoint      = "https://infra-appconfig.azconfig.io"
-    azure_app_config_resource_id   = "/subscriptions/aee0cbd2-8074-4001-b610-0f8edb4eaa3c/resourceGroups/infra/providers/Microsoft.AppConfiguration/configurationStores/infra-appconfig"
-    key_vault_name                 = "romaine-kv"
+    resource_group_name          = "infra"
+    dns_zone_name                = "romaine.life"
+    cosmos_db_account_name       = "infra-cosmos"
+    cosmos_db_account_id         = "/subscriptions/aee0cbd2-8074-4001-b610-0f8edb4eaa3c/resourceGroups/infra/providers/Microsoft.DocumentDB/databaseAccounts/infra-cosmos"
+    azure_app_config_endpoint    = "https://infra-appconfig.azconfig.io"
+    azure_app_config_resource_id = "/subscriptions/aee0cbd2-8074-4001-b610-0f8edb4eaa3c/resourceGroups/infra/providers/Microsoft.AppConfiguration/configurationStores/infra-appconfig"
+    key_vault_name               = "romaine-kv"
   }
 }

--- a/tofu/remote-state.tf
+++ b/tofu/remote-state.tf
@@ -6,8 +6,6 @@ locals {
     cosmos_db_account_id           = "/subscriptions/aee0cbd2-8074-4001-b610-0f8edb4eaa3c/resourceGroups/infra/providers/Microsoft.DocumentDB/databaseAccounts/infra-cosmos"
     azure_app_config_endpoint      = "https://infra-appconfig.azconfig.io"
     azure_app_config_resource_id   = "/subscriptions/aee0cbd2-8074-4001-b610-0f8edb4eaa3c/resourceGroups/infra/providers/Microsoft.AppConfiguration/configurationStores/infra-appconfig"
-    auth0_domain                   = "auth.romaine.life"
-    auth0_connection_apple_id      = "con_DM1he2xMWnIQiVgg"
     key_vault_name                 = "romaine-kv"
   }
 }


### PR DESCRIPTION
Cleanup after Auth0 → Microsoft OAuth + URL-fragment JWT migration. No remaining consumers. Plan should be no-op.